### PR TITLE
fix: empty symbol

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/src/fluent-icon-element.js
+++ b/src/fluent-icon-element.js
@@ -1562,8 +1562,11 @@ const SEGOE_FLUENT_ICONS_GLYPH_MAP = [
         }
 
         setSymbol() {
-            const glyph = this.glyphMap.find(map => map.name === this.symbol).glyph;
-            super.glyph = "&#x" + glyph;
+            const glyph = this.symbol
+                ? "&#x" + this.glyphMap.find(map => map.name === this.symbol).glyph
+                : "";
+
+            super.glyph = glyph;
         }
     }
 
@@ -1649,8 +1652,7 @@ const SEGOE_FLUENT_ICONS_GLYPH_MAP = [
         }
 
         setSource() {
-            if(this.source)
-                this.image.setAttribute("src", this.source);
+            this.image.setAttribute("src", this.source);
         }
 
         setSize() {


### PR DESCRIPTION
~reset glyph (set to empty) when symbol-icon has no symbol value set.
~fixed error when symbol is empty.